### PR TITLE
Add details of the git "safety barriers" 

### DIFF
--- a/03-using-github-in-rstudio.Rmd
+++ b/03-using-github-in-rstudio.Rmd
@@ -175,6 +175,16 @@ The slides from from the ASD git training are [available here (dom1 access only)
     - [Learn Git branching](http://learngitbranching.js.org/)
     - [Git from the inside out](https://maryrosecook.com/blog/post/git-from-the-inside-out)
 
+## Safety barriers
+
+The platform has configured simple "safety barriers" to reduce risk of accidentally exposing sensitive data on GitHub. For example it stops you committing a CSV file, because in most circumstances you should not put data into GitHub - it should be kept in an S3 bucket where it can be shared with authorized people. These rules can be overridden if that makes more sense.
+
+| What | How it's configured | Reasoning | How to override |
+|------|-------------------------------|-----------|-----------------|
+| Data files (.csv, .xls etc) & zip files | ~/.gitignore | You should not put data into GitHub - it should be kept in an S3 bucket where it can be shared with authorized people. | When you add the file: `git add -f <filename>` |
+| Zip files | ~/.gitignore | It's better to unpack these files and commit the raw source. You can't keep track of diffs of individual files if you keep them bundled up. There might be a data file lurking in the zip, which isn't checked if it is bundled like this. Note: git has its own built in compression methods. | When you add the file: `git add -f <filename>` |
+| Large files (>5 Mb) | ~/.git-templates/hooks/pre-commit | Likely to be data | When you commit: `git commit --no-verify` |
+| Pushing to non-official GitHub organizations | ~/.git-templates/hooks/pre-push | It would be outside MoJ control - not normally allowed. | When you push: `git push -f <remote> <branch>` |
 
 ## Other tips and tricks [Work in progress!]:
 


### PR DESCRIPTION
I thought of the name 'safety barriers'. There may be a better or more standard name.

These are barriers are configured by default by: https://github.com/ministryofjustice/analytics-platform-helm-charts/blob/master/charts/config-user/files/git-config.sh