### PR TITLE
Change dash to underscore in AP team email address

### DIFF
--- a/10-acceptable-use-policy.Rmd
+++ b/10-acceptable-use-policy.Rmd
@@ -15,7 +15,7 @@ This policy applies to all users of the Analytical Platform.
 __All users will:__
 
 * report any security incidents, including a loss of data, in line with the relevant MoJ, HMPPS or HMCTS procedures;
-* report any breach of this acceptable use policy to the [Analytical Platform team](mailto:analytical-platform@digital.justice.gov.uk);
+* report any breach of this acceptable use policy to the [Analytical Platform team](mailto:analytical_platform@digital.justice.gov.uk);
 * follow all relevant information governance procedures;
 * protect their login credentials appropriately;
 * create secure passwords following best practice guidelines (see [here](https://www.ncsc.gov.uk/blog-post/three-random-words-or-thinkrandom-0));

--- a/11-information_governance.Rmd
+++ b/11-information_governance.Rmd
@@ -10,7 +10,7 @@ If you are an admin for data source, you can control which users have access fro
 
 Some app access permissions can be specified in `deploy.json` (see Section \@ref(grant-app-access)), however, users cannot manage an app's user access list themselves.
 
-DOM1 and MacBook users can request access to a data source (for themselves, other users or customers) on the [#ap-admin-request](https://asdslack.slack.com/messages/CBLAGCQG6/) Slack channel. Quantum users should email the [Analytical Platform team](mailto:analytical-platform@digital.justice.gov.uk).
+DOM1 and MacBook users can request access to a data source (for themselves, other users or customers) on the [#ap-admin-request](https://asdslack.slack.com/messages/CBLAGCQG6/) Slack channel. Quantum users should email the [Analytical Platform team](mailto:analytical_platform@digital.justice.gov.uk).
 
 If requesting access to a data source, you should provide the GitHub usernames of the relevant users. If requesting access to an app, you should provide the email addresses of the relevant users.
 
@@ -28,7 +28,7 @@ If requesting access to a data source, you should provide the GitHub usernames o
 * Files stored in users' home directories are backed up to Amazon S3 automatically.
 * Previous versions of files stored in users' home directories are also backed up to Amazon S3.
 * Once files are deleted from a user's home directory, the backup is retained for a further 90 days and can be restored.
-* To request that a file be restored or to access a previous version of a file, contact the [Analytical Platform team](mailto:analytical-platform@digital.justice.gov.uk).
+* To request that a file be restored or to access a previous version of a file, contact the [Analytical Platform team](mailto:analytical_platform@digital.justice.gov.uk).
 
 #### Best practice guidelines
 
@@ -141,9 +141,9 @@ A privacy notice is required to let customers using a product or service know:
 * __How will the data be moved?__  
   Describe how the data will be moved from the source location. Will the data be moved electronically, by email or by physical media? Will it be uploaded manually to S3 or a home directory or will there be a direct integration with another system?
 * __Is a technical migration form required?__  
-  A technical migration form is __not required__ for one-off data movements of static files (such as .zip files and .csv files) that are carried out manually (i.e. by email or direct upload to S3 or a home directory). __A technical migration form is required for all other data movements.__ If you are unsure whether your data movement requires a technical migration form, please contact the [Analytical Platform team](mailto:analytical-platform@digital.justice.gov.uk).
+  A technical migration form is __not required__ for one-off data movements of static files (such as .zip files and .csv files) that are carried out manually (i.e. by email or direct upload to S3 or a home directory). __A technical migration form is required for all other data movements.__ If you are unsure whether your data movement requires a technical migration form, please contact the [Analytical Platform team](mailto:analytical_platform@digital.justice.gov.uk).
 * __Technical migration form__  
-  Upload the complete technical migration form (maximum size 1GB). If you do not have an @digital email address and cannot upload a file to the form, please send the form as an attachment to the [Analytical Platform team](mailto:analytical-platform@digital.justice.gov.uk).
+  Upload the complete technical migration form (maximum size 1GB). If you do not have an @digital email address and cannot upload a file to the form, please send the form as an attachment to the [Analytical Platform team](mailto:analytical_platform@digital.justice.gov.uk).
 * __Is this a one-off or recurring data movement?__
 * __When is the data movement expected to occur?__
 * __What is the intended frequency of the data movement?__


### PR DESCRIPTION
Some instances of the AP team email address had been incorrectly written using a dash as opposed to an underscore.