### PR TITLE
Add remaining concourse state colours

### DIFF
--- a/08-build_and_deploy.Rmd
+++ b/08-build_and_deploy.Rmd
@@ -23,20 +23,26 @@ Your task appears in Concourse within 30 seconds. Find it in Concourse to start 
 1. Open Concourse: https://concourse.services.alpha.mojanalytics.xyz/
 2. Select team 'main'.
 3. Click 'login with ap-main' followed by your GitHub login and possibly 2FA for GitHub and possibly 2FA for AP.
-4. Click the hamburger icon: ![](images/build_and_deploy/concourse_menu.png) (top-left) to see the list of repos that can be built.
+4. Click the hamburger icon: ![Hamburger menu icon](images/build_and_deploy/concourse_menu.png) (top-left) to see the list of repos that can be built.
 5. Click your repo name to see its diagram with the big 'Deploy' box in the middle, inputs and outputs.
 6. Click on the 'deploy' box to see details of its builds. You can see previous builds (numbered - e.g. "8 7 6 5 4 3 2 1"). The colour of the build number box gives the status:
     * Grey = paused or pending
     * Yellow = in progress
+    * Blue = paused
     * Green = built ok
     * Red = build failed
+    * Brown = aborted
+    * Orange = errored
 7. To start the job (this first time): Click *play* (on the left, against your repo name) AND the "*+*":
-   ![](images/build_and_deploy/concourse_new_build.png)
+   ![Play and "+" buttons](images/build_and_deploy/concourse_new_build.png)
+
    It should go grey (pending)
-   ![](images/build_and_deploy/concourse_pending.png)
+   ![Pending state](images/build_and_deploy/concourse_pending.png)
+
    After 30 seconds it should got yellow (building). If it does not go yellow, check the task is not paused (and possibly the job itself is paused) - press play if is showing.
-   ![](images/build_and_deploy/concourse_in_progress.png)
+   ![In progress state](images/build_and_deploy/concourse_in_progress.png)
+
    It will build/deploy, taking 5 minutes to an hour. You can track progress and see any errors like this:
-   ![](images/build_and_deploy/concourse_error.png)
+   ![Error state](images/build_and_deploy/concourse_error.png)
 
 Subsequent build/deploys are started about 5 seconds after doing a GitHub release (unless someone pressed the pause button on the Concourse task). You have to refresh Concourse in your browser to see a fresh build.


### PR DESCRIPTION
I added the remaining colours from the concourse key. I'd add the pic, but explaining the pending state also means paused is more helpful.
![Screen Shot 2019-03-06 at 12 28 17](https://user-images.githubusercontent.com/307612/54195404-7b025d80-44b6-11e9-8595-0a679c04732c.png)

I added some alt text to the pics, for accessibility.