### PR TITLE
Add link to the runbook for senior stakeholders

### DIFF
--- a/01-quick_start.Rmd
+++ b/01-quick_start.Rmd
@@ -60,3 +60,5 @@ See [Deploying a Shiny App ][Deploying a Shiny App ].
 ## Contacting us
 
 For quick support, contact us on the `#analytical_platform` [Slack channel](https://asdslack.slack.com/messages/anaytical_platform/). Alternatively, contact us by [email](mailto:analytical_platform@digital.justice.gov.uk)
+
+For full details of support, including incident response, please see the [AP Runbook's Key Support Information](https://github.com/ministryofjustice/analytics-platform-ops/wiki/Key-support-information).

--- a/12-support_routes.Rmd
+++ b/12-support_routes.Rmd
@@ -2,7 +2,7 @@
 
 ## Summary
 
-- The Analytical Platform team in Digitech are responsible for providing access to software like R Studio and Jupyter.
+- The Analytical Platform team in MOJ Digital & Technology is responsible for providing access to software like R Studio and Jupyter.
 - Analysts themselves are responsible for the code they write in these tools, and the Platform team is not responsible for assisting with problems with this code.  As a rule of thumb, if the problem you're experiencing would also occur with R Studio or Python installed on a standalone computer, then the platform team don't offer support.
 - If you've read through the user guidance and are still stuck, the best place to go for support is the [analytical-platform](https://asdslack.slack.com/messages/C4PF7QAJZ/#) Slack channel for issues with the platform, or [the R channel](https://asdslack.slack.com/messages/C1PUCG719/#) and [python channel](https://asdslack.slack.com/messages/C1Q09V86S/#) to get support from peers in your code.
 


### PR DESCRIPTION
This seems a good place as any to add a link to the Key Support Info.