### PR TITLE
Use new "create repo from template" GitHub feature

### DIFF
--- a/05-deploying_shiny_app.Rmd
+++ b/05-deploying_shiny_app.Rmd
@@ -21,7 +21,7 @@ To create and deploy a Shiny app, you should complete the following steps:
 
 To create a new repository based on the Shiny app template:
 
-1. Go to the [rshiny-template repo](https://github.com/moj-analytical-services/rshiny-template).
+1. Go to the [rshiny-template](https://github.com/moj-analytical-services/rshiny-template) repository.
 2. Click __Use this template__.
 3. Fill in the form:
     + Owner: `moj-analytical-services`

--- a/05-deploying_shiny_app.Rmd
+++ b/05-deploying_shiny_app.Rmd
@@ -25,7 +25,7 @@ To create a new repository based on the Shiny app template:
 2. Click __Use this template__.
 3. Fill in the form:
     + Owner: `moj-analytical-services`
-    + Name: The name of your app, e.g., `my-app`
+    + Name: The name of your app, for example, `my-app`
     + Privacy: Private
 4. Select __Create repository from template__.
 

--- a/05-deploying_shiny_app.Rmd
+++ b/05-deploying_shiny_app.Rmd
@@ -19,7 +19,7 @@ To create and deploy a Shiny app, you should complete the following steps:
 
 ### Use the app template{#use-template}
 
-To create a new repo for the app, use the R Shiny app template:
+To create a new repository based on the Shiny app template:
 
 1. Go to the [rshiny-template repo](https://github.com/moj-analytical-services/rshiny-template).
 2. Click __Use this template__.

--- a/05-deploying_shiny_app.Rmd
+++ b/05-deploying_shiny_app.Rmd
@@ -22,7 +22,7 @@ To create and deploy a Shiny app, you should complete the following steps:
 To create a new repository based on the Shiny app template:
 
 1. Go to the [rshiny-template](https://github.com/moj-analytical-services/rshiny-template) repository.
-2. Click __Use this template__.
+2. Select __Use this template__.
 3. Fill in the form:
     + Owner: `moj-analytical-services`
     + Name: The name of your app, for example, `my-app`

--- a/05-deploying_shiny_app.Rmd
+++ b/05-deploying_shiny_app.Rmd
@@ -6,7 +6,7 @@
 
 To create and deploy a Shiny app, you should complete the following steps:
 
-1.  [Copy the app template](#copy-template).
+1.  [Use the app template](#use-template).
 2.  [Create a new webapp](#create-webapp).
 3.  [Clone the repository](#clone-repo).
 4.  [Develop the app](#develop-the-app).
@@ -17,21 +17,19 @@ To create and deploy a Shiny app, you should complete the following steps:
 9.  [Add users to the app](#add-users).
 10. [Access the app](#access-the-app).
 
-### Copy the app template{#copy-template}
+### Use the app template{#use-template}
 
-To copy the app template:
+To create a new repo for the app, use the R Shiny app template:
 
-1.  Go to [github.com/new/import](https://github.com/new/import).
-2.  Fill in the form:
-    +   Your old repository’s clone URL: `https://github.com/moj-analytical-services/rshiny-template`
-    +   Owner: `moj-analytical-services`
-    +   Name: The name of your app, e.g., `my-app`
-    +   Privacy: Private
-6.  Select __Begin import__.
+1. Go to the [rshiny-template repo](https://github.com/moj-analytical-services/rshiny-template).
+2. Click __Use this template__.
+3. Fill in the form:
+    + Owner: `moj-analytical-services`
+    + Name: The name of your app, e.g., `my-app`
+    + Privacy: Private
+4. Select __Create repository from template__.
 
 This copies the entire contents of the app template to a new repository.
-
-![](images/shiny/copy-template.png)
 
 ### Create a new webapp{#create-webapp}
 

--- a/06-deploying_static.Rmd
+++ b/06-deploying_static.Rmd
@@ -21,7 +21,7 @@ To create a new repo for the app, use the webapp template:
 2. Select __Use this template__.
 3. Fill in the form:
     + Owner: `moj-analytical-services`
-    + Name: The name of your app, e.g., `my-app`
+    + Name: The name of your app, for example, `my-app`
     + Privacy: Private
 4. Select __Create repository from template__.
 

--- a/06-deploying_static.Rmd
+++ b/06-deploying_static.Rmd
@@ -13,20 +13,19 @@ Step-by-step instructions are below.
 
 ## Step-by-step guide to depolying an static web app
 
-### Copy the template project into a new Github repository
+### Use the webapp template
 
-1. Begin by making a **copy** of the [template project](https://github.com/moj-analytical-services/webapp-template) on Github: https://github.com/new/import
+To create a new repo for the app, use the webapp template:
 
-2. Enter `https://github.com/moj-analytical-services/webapp-template` in the input box entitled 'your old repository’s clone URL:'
+1. Go to the [webapp-template repo](https://github.com/moj-analytical-services/webapp-template).
+2. Click __Use this template__.
+3. Fill in the form:
+    + Owner: `moj-analytical-services`
+    + Name: The name of your app, e.g., `my-app`
+    + Privacy: Private
+4. Select __Create repository from template__.
 
-3. Ensure the 'owner' of the new repository is 'moj-analytical-services' and choose a name for your repository:
-
-4. Make sure the repo is 'private' (this should be the default value):
-
-5. Click 'Begin import'
-
-
-   ![](images/static/static_clone.gif)
+This copies the entire contents of the app template to a new repository.
 
 ### In your chosen development enviroment, clone the git repository
 

--- a/06-deploying_static.Rmd
+++ b/06-deploying_static.Rmd
@@ -17,7 +17,7 @@ Step-by-step instructions are below.
 
 To create a new repository based on the webapp template:
 
-1. Go to the [webapp-template repo](https://github.com/moj-analytical-services/webapp-template).
+1. Go to the [webapp-template](https://github.com/moj-analytical-services/webapp-template) repository.
 2. Select __Use this template__.
 3. Fill in the form:
     + Owner: `moj-analytical-services`

--- a/06-deploying_static.Rmd
+++ b/06-deploying_static.Rmd
@@ -15,7 +15,7 @@ Step-by-step instructions are below.
 
 ### Use the webapp template
 
-To create a new repo for the app, use the webapp template:
+To create a new repository based on the webapp template:
 
 1. Go to the [webapp-template repo](https://github.com/moj-analytical-services/webapp-template).
 2. Select __Use this template__.

--- a/06-deploying_static.Rmd
+++ b/06-deploying_static.Rmd
@@ -18,7 +18,7 @@ Step-by-step instructions are below.
 To create a new repo for the app, use the webapp template:
 
 1. Go to the [webapp-template repo](https://github.com/moj-analytical-services/webapp-template).
-2. Click __Use this template__.
+2. Select __Use this template__.
 3. Fill in the form:
     + Owner: `moj-analytical-services`
     + Name: The name of your app, e.g., `my-app`


### PR DESCRIPTION
Using the new feature: https://github.blog/2019-06-06-generate-new-repositories-with-repository-templates/ makes it simpler / more intuitive to start off apps.

I've not bothered to do an animated gif - I'm in two minds about these. Sometimes I find them really helpful, and sometimes I just get confused as they whizz by, and I can't start them at the beginning.