### PR TITLE
Fix broken link to AWS management console

### DIFF
--- a/03-amazon_s3.Rmd
+++ b/03-amazon_s3.Rmd
@@ -90,7 +90,7 @@ You can use the Amazon S3 Console to upload files from your local computer (for 
 
 To upload files using the Amazon S3 Console:
 
-1.  Log in to the [AWS Management Console](https://http://aws.services.alpha.mojanalytics.xyz) using your Analytical Platform account.
+1.  Log in to the [AWS Management Console](https://aws.services.alpha.mojanalytics.xyz) using your Analytical Platform account.
 2.  Select __Services__ from the menu bar.
 3.  Select __S3__ from the drop down menu.
 4.  Select the bucket and folder you want to upload files to.


### PR DESCRIPTION
Removes an erroneous extra `http://` from a link to the AWS management console.