### PR TITLE
Updated conda "reset" command

### DIFF
--- a/15-Appendix.Rmd
+++ b/15-Appendix.Rmd
@@ -107,7 +107,7 @@ Recommended before starting a new project. Will ensure that no unused
 dependencies are exported when you export an `environment.yml` for this project.
 
 ```bash
-conda env export -n base| grep -v "^prefix: " > /tmp/base.yml && conda env update --prune -n rstudio -f /tmp/base.yml && rm /tmp/base.yml
+conda deactivate; conda env remove -n rstudio; rm -rf ~/.conda/envs/rstudio/; conda create --use-index-cache --clone root -n rstudio --copy -y --offline; conda activate rstudio
 ```
 
 ### Exporting your _Environment_


### PR DESCRIPTION
The old command was exporting the `base` environment and updating the
`rstudio` one. This can result into problem when:
- a user upgraded one of the packages (in the `rstudio` env)
- the original version of this package (in the `base` env) is removed
  from the repository/channel, e.g. because of a security vulnerability

This "new" reset command(s) uses the same command used in the [`Dockerfile`]
when creating the `rstudio` environment by cloning `root`/`base` (with
the addition of the `--offline` flag). This should also be faster.

The new reset command deactivate/remove the `rstudio` environment and also
deletes its `~/.conda/envs/rstudio/` directory first - `conda` would complain
otherwise.

From my tests in my RStudio environment it seems to work as expected.

[`Dockerfile`]: https://github.com/ministryofjustice/analytics-platform-rstudio/blob/master/start.sh#L41