### PR TITLE
Add IP whitelist "Digital Wifi and VPN"

### DIFF
--- a/05-deploying_shiny_app.Rmd
+++ b/05-deploying_shiny_app.Rmd
@@ -85,11 +85,18 @@ The list is stored in a file called `packrat/packrat.lock`. You must ensure that
 
 You can set some access permissions for your app in the `deploy.json` file that is included with the app template. This file is used by Concourse to detect apps that are ready to build and deploy.
 
-The `allowed_ip_ranges` parameter controls where your app can be accessed from. It can take any combination of the following values `["DOM1", "QUANTUM", "102PF Wifi"]` or `["Any"]`.
+| parameter | notes |
+| --------- | ------- |
+| `allowed_ip_ranges` | e.g. `["DOM1", "QUANTUM", "102PF Wifi", "Digital Wifi and VPN"]` or `["Any"]`|
+| `disable_authentication` | To let anyone access the app (subject to the allowed_ip_ranges), set this to `true`, otherwise `false` restricts it to people authorized for the app in the Control Panel |
+
+The `allowed_ip_ranges` parameter controls where your app can be accessed from. It can take any combination of the listed network IPs or `["Any"]`.
 
 The `disable_authentication` parameter controls whether sign-in (using a link or one-time passcode sent to an authorised email address) is required for users to access the app. It can take the values `true` or `false`. In general, this should be set to `false`.
 
 When `disable_authentication` is set to `true`, users do not need to go through a sign-in process but can still only access an app using a system specified in `allowed_ip_ranges`. This is a relatively weak security measure, as discussed [here](https://ministryofjustice.github.io/security-guidance/standards/authentication/#ip-addresses). As such, if you wish to disable authentication, you should first discuss this with the Analytical Platform team.
+
+Changes to deploy.json only take effect when committed to GitHub, a Release is created and the deploy is successful (see [Scan organisation and deploy][Scan organisation and deploy])
 
 ### Create a release in GitHub{#create-release}
 

--- a/05-deploying_shiny_app.Rmd
+++ b/05-deploying_shiny_app.Rmd
@@ -85,18 +85,13 @@ The list is stored in a file called `packrat/packrat.lock`. You must ensure that
 
 You can set some access permissions for your app in the `deploy.json` file that is included with the app template. This file is used by Concourse to detect apps that are ready to build and deploy.
 
-| parameter | notes |
-| --------- | ------- |
-| `allowed_ip_ranges` | e.g. `["DOM1", "QUANTUM", "102PF Wifi", "Digital Wifi and VPN"]` or `["Any"]`|
-| `disable_authentication` | To let anyone access the app (subject to the allowed_ip_ranges), set this to `true`, otherwise `false` restricts it to people authorized for the app in the Control Panel |
+The `allowed_ip_ranges` parameter controls where your app can be accessed from. It can take any combination of `["DOM1", "QUANTUM", "102PF Wifi", "Digital Wifi and VPN"]` or `["Any"]`.
 
-The `allowed_ip_ranges` parameter controls where your app can be accessed from. It can take any combination of the listed network IPs or `["Any"]`.
-
-The `disable_authentication` parameter controls whether sign-in (using a link or one-time passcode sent to an authorised email address) is required for users to access the app. It can take the values `true` or `false`. In general, this should be set to `false`.
+The `disable_authentication` parameter controls whether sign-in (using a link or one-time passcode sent to an authorised email address) is required for users to access the app when on an allowed network. It can take the values `true` or `false`. In general, this should be set to `false`.
 
 When `disable_authentication` is set to `true`, users do not need to go through a sign-in process but can still only access an app using a system specified in `allowed_ip_ranges`. This is a relatively weak security measure, as discussed [here](https://ministryofjustice.github.io/security-guidance/standards/authentication/#ip-addresses). As such, if you wish to disable authentication, you should first discuss this with the Analytical Platform team.
 
-Changes to deploy.json only take effect when committed to GitHub, a Release is created and the deploy is successful (see [Scan organisation and deploy][Scan organisation and deploy])
+Changes to `deploy.json` only take effect when they are committed to GitHub, a release is created and the deployment is successful (see [Scan organisation and deploy][Scan organisation and deploy]).
 
 ### Create a release in GitHub{#create-release}
 

--- a/06-deploying_static.Rmd
+++ b/06-deploying_static.Rmd
@@ -60,20 +60,17 @@ You can also let anyone access it by setting `"disable_authentication": true` in
 
 **Note** that users can only access the app from a computer on a specified corporate network. These are defined in the `deploy.json` under the parameter `allowed_ip_ranges` - see below.
 
-#### deploy.json
+#### Set access permissions
 
-| parameter | notes |
-| --------- | ------- |
-| `allowed_ip_ranges` | e.g. `["DOM1", "QUANTUM", "102PF Wifi", "Digital Wifi and VPN"]` or `["Any"]`|
-| `disable_authentication` | To let anyone access the app (subject to the allowed_ip_ranges), set this to `true`, otherwise `false` restricts it to people authorized for the app in the Control Panel |
+You can set some access permissions for your app in the `deploy.json` file that is included with the app template. This file is used by Concourse to detect apps that are ready to build and deploy.
 
-The `allowed_ip_ranges` parameter controls where your app can be accessed from. It can take any combination of the listed network IPs or `["Any"]`.
+The `allowed_ip_ranges` parameter controls where your app can be accessed from. It can take any combination of `["DOM1", "QUANTUM", "102PF Wifi", "Digital Wifi and VPN"]` or `["Any"]`.
 
-The `disable_authentication` parameter controls whether sign-in (using a link or one-time passcode sent to an authorised email address) is required for users to access the app. It can take the values `true` or `false`. In general, this should be set to `false`.
+The `disable_authentication` parameter controls whether sign-in (using a link or one-time passcode sent to an authorised email address) is required for users to access the app when on an allowed network. It can take the values `true` or `false`. In general, this should be set to `false`.
 
 When `disable_authentication` is set to `true`, users do not need to go through a sign-in process but can still only access an app using a system specified in `allowed_ip_ranges`. This is a relatively weak security measure, as discussed [here](https://ministryofjustice.github.io/security-guidance/standards/authentication/#ip-addresses). As such, if you wish to disable authentication, you should first discuss this with the Analytical Platform team.
 
-Changes to deploy.json only take effect when committed to GitHub, a Release is created and the deploy is successful (see [Scan organisation and deploy][Scan organisation and deploy])
+Changes to `deploy.json` only take effect when they are committed to GitHub, a release is created and the deployment is successful (see [Scan organisation and deploy][Scan organisation and deploy]).
 
 ## Accessing the app
 

--- a/06-deploying_static.Rmd
+++ b/06-deploying_static.Rmd
@@ -64,13 +64,16 @@ You can also let anyone access it by setting `"disable_authentication": true` in
 
 | parameter | notes |
 | --------- | ------- |
-| `allowed_ip_ranges` | e.g. `["DOM1", "QUANTUM", "102PF Wifi"]` or `["Any"]`|
-| `disable_authentication` | To let anyone access the app, set this to `true`, otherwise `false` restricts it to people authorized for the app in the Control Panel |
+| `allowed_ip_ranges` | e.g. `["DOM1", "QUANTUM", "102PF Wifi", "Digital Wifi and VPN"]` or `["Any"]`|
+| `disable_authentication` | To let anyone access the app (subject to the allowed_ip_ranges), set this to `true`, otherwise `false` restricts it to people authorized for the app in the Control Panel |
 
-If you deployed with authentication enabled users are granted access to the app using a list of email addresses separated with a space, comma or semicolon.
+The `allowed_ip_ranges` parameter controls where your app can be accessed from. It can take any combination of the listed network IPs or `["Any"]`.
+
+The `disable_authentication` parameter controls whether sign-in (using a link or one-time passcode sent to an authorised email address) is required for users to access the app. It can take the values `true` or `false`. In general, this should be set to `false`.
+
+When `disable_authentication` is set to `true`, users do not need to go through a sign-in process but can still only access an app using a system specified in `allowed_ip_ranges`. This is a relatively weak security measure, as discussed [here](https://ministryofjustice.github.io/security-guidance/standards/authentication/#ip-addresses). As such, if you wish to disable authentication, you should first discuss this with the Analytical Platform team.
 
 Changes to deploy.json only take effect when committed to GitHub, a Release is created and the deploy is successful (see [Scan organisation and deploy][Scan organisation and deploy])
-
 
 ## Accessing the app
 

--- a/08-build_and_deploy.Rmd
+++ b/08-build_and_deploy.Rmd
@@ -27,7 +27,7 @@ Your task appears in Concourse within 30 seconds. Find it in Concourse to start 
 5. Click your repo name to see its diagram with the big 'Deploy' box in the middle, inputs and outputs.
 6. Click on the 'deploy' box to see details of its builds. You can see previous builds (numbered - e.g. "8 7 6 5 4 3 2 1"). The colour of the build number box gives the status:
     * Grey = paused or pending
-    * Yellow = in progress
+    * Yellow = in progress (building/deploying)
     * Blue = paused
     * Green = built ok
     * Red = build failed
@@ -39,7 +39,7 @@ Your task appears in Concourse within 30 seconds. Find it in Concourse to start 
    It should go grey (pending)
    ![Pending state](images/build_and_deploy/concourse_pending.png)
 
-   After 30 seconds it should got yellow (building). If it does not go yellow, check the task is not paused (and possibly the job itself is paused) - press play if is showing.
+   After 30 seconds it should go yellow (building/deploying). If it does not go yellow, check the task is not paused (and possibly the job itself is paused) - press play if it is showing.
    ![In progress state](images/build_and_deploy/concourse_in_progress.png)
 
    It will build/deploy, taking 5 minutes to an hour. You can track progress and see any errors like this:


### PR DESCRIPTION
* "Digital Wifi and VPN" added, as per https://github.com/ministryofjustice/analytics-platform-common-concourse-tasks/pull/14
* a bit of consistency about deploy.json between  05-deploying_shiny_app.Rmd and 06-deploying_static.Rmd
* minor fix in the concourse chapter