### PR TITLE
User Info Documentation for Auth-Proxy

### DIFF
--- a/05-deploying_shiny_app.Rmd
+++ b/05-deploying_shiny_app.Rmd
@@ -144,6 +144,63 @@ A Shiny app can find out who is using it. This can be useful to log an audit tra
 
 See the example: https://github.com/moj-analytical-services/shiny-headers-demo
 
+Note: these features require you to be using the Analytical platform's version of `shiny-server`.
+
+#### Email address
+
+
+You can obtain the logged in user's email address by using the following code in the `server` function of your app:
+
+```r
+get("HTTP_USER_EMAIL", envir=session$request)
+```
+
+[This line](https://github.com/moj-analytical-services/shiny-headers-demo/blob/c274d864e5ee020d3a41497b347b299c07305271/app.R#L58)
+in `shiny-headers-demo` shows the code in context.
+
+#### Full user profile
+
+You can access the full user profile by making a request directly from the shiny
+app to the auth-proxy's `/userinfo` endpoint using the following code inside your `server` function.
+
+```r
+# these libraries are required
+# library(httr)
+# library(jsonlite)
+
+profile <- fromJSON(content(GET("http://localhost:3001/userinfo", add_headers(cookie=get("HTTP_COOKIE", envir=session$request))), "text"))
+```
+
+[This line](https://github.com/moj-analytical-services/shiny-headers-demo/blob/c274d864e5ee020d3a41497b347b299c07305271/app.R#L61)
+shows the code in context.
+
+##### Example User Info Response
+```json
+{
+    "email": "name@example.gov.uk",
+    "email_verified": true,
+    "user_id": "email|12345121312",
+    "picture": "https://s.gravatar.com/avatar/94deebe3b87fc5e9b3b4469112573cc0?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fna.png",
+    "nickname": "name",
+    "identities": [
+        {
+            "user_id": "12345121312",
+            "provider": "email",
+            "connection": "email",
+            "isSocial": false
+        }
+    ],
+    "updated_at": "2019-07-15T09:54:34.353Z",
+    "created_at": "2018-07-12T14:26:45.663Z",
+    "name": "name@example.gov.uk",
+    "last_ip": "1.1.1.1",
+    "last_login": "2019-07-15T09:54:34.353Z",
+    "logins_count": 20,
+    "blocked_for": [],
+    "guardian_authenticators": []
+}
+```
+
 ## Troubleshooting
 
 ### Common errors


### PR DESCRIPTION
This explains how to access the `/userinfo` endpoint on the auth proxy with
links to examples in the shiny-headers demo app.