### PR TITLE
Update information governance guidance based on DPO advice

### DIFF
--- a/11-information_governance.Rmd
+++ b/11-information_governance.Rmd
@@ -32,7 +32,7 @@ When requesting access to a data source, you should provide the GitHub usernames
 
 ## Data movements
 
-You can move data classified as OFFICIAL and OFFICIAL-SENSITIVE onto the Analytical Platform. SECRET and TOP SECRET data is not allowed on the Analytical Platform.
+You can move data classified as OFFICIAL (including OFFICIAL-SENSITIVE) onto the Analytical Platform. SECRET and TOP SECRET data is not allowed on the Analytical Platform.
 
 All data movements should take place safely and securely to ensure that data is protected at all times, including when in transit.
 
@@ -40,7 +40,7 @@ The process of moving data to the Analytical Platform is different depending on 
 
 ### Personal data
 
-If you are working with personal data you have a responsibility to ensure that you are compliant with the requirements of the General Data Protection Regulation (GDPR) and the Data Protection Act (DPA) 2018.
+If you are working with personal data you have a responsibility to ensure that you are compliant with the requirements of the General Data Protection Regulation (GDPR) and the Data Protection Act (DPA) 2018. This responsibility applies regardless of where you are processing the data.
 
 In practice, this means you must ensure that:
 
@@ -110,9 +110,9 @@ The data controller could be another MoJ agency or public body (for which MoJ is
 
 If you want to move personal data onto the Analytical Platform, you should check if a [Data Protection Impact Assessment (DPIA)](https://intranet.justice.gov.uk/guidance/knowledge-information/protecting-information/privacy-reform/data-protection-impact-assessments-dpias/) or Privacy Impact Assessment (PIA) already exists for the processing of the personal data. The Information Asset Owner (IAO) of the data should be able to advise you if a DPIA or PIA already exists.
 
-If a DPIA or PIA already exists, you should update the document to reflect use of the Analytical Platform.
+If a DPIA or PIA already exists, you should update the document to reflect use of the Analytical Platform. You should ensure that any changes are reviewed and approved by the IAO.
 
-If a DPIA or PIA does not already exist, you should complete a [DPIA screening document](https://intranet.justice.gov.uk/documents/2018/05/data-protection-impact-assessments-screening-template.doc) and submit this to the Data Protection Officer (DPO) at [data.compliance@justice.gov.uk](mailto:data.compliance@justice.gov.uk).
+If a DPIA or PIA does not already exist, you should complete a [DPIA screening document](https://intranet.justice.gov.uk/documents/2018/05/data-protection-impact-assessments-screening-template.doc) and submit this to the Data Protection Officer (DPO) at [data.compliance@justice.gov.uk](mailto:data.compliance@justice.gov.uk). You should also submit a final copy of the document to the Analytical Platform team at [analytical_platform@digital.justice.gov.uk](mailto:analytical_platform@digital.justice.gov.uk).
 
 You should also check if a [privacy notice](https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/individual-rights/right-to-be-informed/) already exists. A privacy notice provides information to individuals about how and why their personal data is being collected and processed.
 

--- a/11-information_governance.Rmd
+++ b/11-information_governance.Rmd
@@ -36,7 +36,7 @@ You can move data classified as OFFICIAL (including OFFICIAL-SENSITIVE) onto the
 
 All data movements should take place safely and securely to ensure that data is protected at all times, including when in transit.
 
-The process of moving data to the Analytical Platform is different depending on whether you are working with personal data.
+If you want to move personal data onto the Analytical Platform, you may need to complete some additional steps.
 
 ### Personal data
 

--- a/11-information_governance.Rmd
+++ b/11-information_governance.Rmd
@@ -4,17 +4,17 @@
 
 ### Permissions and access
 
-Access to data and apps on the Analytical Platform should be provided on a need-to-know basis.
+Access to data and apps on the Analytical Platform is provided on a need-to-know basis.
 
-If you are an admin for data source, you can control which users have access from the Analytical Platform control panel.
+If you are an admin for a data source or webapp, you can control which users have access from the Analytical Platform control panel.
 
-Some app access permissions can be specified in `deploy.json` (see Section \@ref(grant-app-access)), however, users cannot manage an app's user access list themselves.
+Some webapp access permissions can also be specified in [`deploy.json`](#rshiny-deploy).
 
-DOM1 and MacBook users can request access to a data source (for themselves, other users or customers) on the [#ap-admin-request](https://asdslack.slack.com/messages/CBLAGCQG6/) Slack channel. Quantum users should email the [Analytical Platform team](mailto:analytical_platform@digital.justice.gov.uk).
+You can request access to a data source or app (for yourself, another user or a customer) by contacting an admin for the data source or app, or by contacting the Analytical Platform team on the [#ap-admin-request](https://asdslack.slack.com/messages/CBLAGCQG6/) Slack channel or at [analytical_platform@digital.justice.gov.uk](mailto:analytical_platform@digital.justice.gov.uk).
 
-If requesting access to a data source, you should provide the GitHub usernames of the relevant users. If requesting access to an app, you should provide the email addresses of the relevant users.
+When requesting access to a data source, you should provide the GitHub usernames of the users to be added. When requesting access to an app, you should provide the email addresses of the users to be added.
 
-### Data retention{#data-retention}
+### Data retention
 
 #### Amazon S3
 
@@ -28,187 +28,119 @@ If requesting access to a data source, you should provide the GitHub usernames o
 * Files stored in users' home directories are backed up to Amazon S3 automatically.
 * Previous versions of files stored in users' home directories are also backed up to Amazon S3.
 * Once files are deleted from a user's home directory, the backup is retained for a further 90 days and can be restored.
-* To request that a file be restored or to access a previous version of a file, contact the [Analytical Platform team](mailto:analytical_platform@digital.justice.gov.uk).
-
-#### Best practice guidelines
-
-All users should comply with the following best practice guidelines for retaining personal data.
-
-__All users will:__
-
-* be aware when they are working with personal data;
-* consider and justify why personal data needs to be retained and for how long;
-* identify when personal data needs to be kept for public interest archiving, scientific or historical research, or statistical purposes;
-* review the need to retain personal data on a regular basis;
-* erase or anonymise personal data when it is no longer required; and
-* erase data as required in accordance with an individual's 'right to be forgotten' under the Data Protection Act 2018.
-
-The relevant information asset owner (IAO) should be able to advise if any additional data retention policies or requirements apply.
+* To request that a file be restored or to access a previous version of a file, contact the Analytical Platform team at [analytical_platform@digital.justice.gov.uk](mailto:analytical_platform@digital.justice.gov.uk).
 
 ## Data movements
 
-All data movements should take place safely and securely to ensure that data is protected at all times, including when in transit. To facilitate this, when moving any data onto the Analytical Platform, you __must__ complete a data movement form. The data movement form can be found <a href="https://forms.office.com/Pages/ResponsePage.aspx?id=KEeHxuZx_kGp4S6MNndq2I8ebMaq5PFBoMAkkhrMYHBUQVY2VUczTUNPUzlZQTJTNjFWVUowWUxUMS4u" target="_blank">here</a>. Guidance on completing the form can be found in Section \@ref(data-movement-form).
+You can move data classified as OFFICIAL and OFFICIAL-SENSITIVE onto the Analytical Platform. SECRET and TOP SECRET data is not allowed on the Analytical Platform.
 
-Depending on the details of the data movement, you may also be required to complete or update:
+All data movements should take place safely and securely to ensure that data is protected at all times, including when in transit.
 
-* A technical migration form;
-* Data protection impact assessments (DPIAs);
-* Privacy impact assessments (PIAs);
-* Privacy notices; or
-* Information management and asset logs.
+The process of moving data to the Analytical Platform is different depending on whether you are working with personal data.
 
-Before completing a data movement form, you should ensure that you have already obtained __all necessary approvals__ and completed all required supplementary documentation.
+### Personal data
 
-### Data movement form guidance{#data-movement-form}
+If you are working with personal data you have a responsibility to ensure that you are compliant with the requirements of the General Data Protection Regulation (GDPR) and the Data Protection Act (DPA) 2018.
 
-You may not be required to complete all of the questions below depending on the details of your data movement.
+In practice, this means you must ensure that:
 
-#### Contact information
+*   you are processing personal data in accordance with the [principles of the GDPR](https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/principles/) and the [rights of individuals](https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/individual-rights/)
+*   you have a lawful basis for processing the personal data
+*   you have fulfilled all necessary governance requirements
 
-* __Name__
-* __Email address__
-* __Phone number__
-* __Is the main person carrying out the data movement the same as the requestor?__
-* __Name of the main person carrying out the data movement__
-* __Email address of the main person carrying out the data movement__
-* __Phone number of the main person carrying out the data movement__
-    
-#### The data
+#### What is personal data?
 
-* __What data is being moved?__  
-* __What fields does the data contain?__
-* __What is the security marking of the data?__  
-  The Analytical Platform is suitable for data classified as OFFICIAL and OFFICIAL-SENSITIVE. SECRET and TOP SECRET data is not allowed on the Analytical Platform.
-  Information on security markings and classifying information can be found [here](https://intranet.justice.gov.uk/guidance/knowledge-information/protecting-information/classifying-information/).
-* __Will the data be modified or changed in order to mask sensitive content or personal information?__  
-  Guidance on masking and anonymisation can be found in sections \@ref(pseudonymisation) and \@ref(anonymisation).
-* __How will the data be changed or modified in order to mask sensitive content or personal information?__
-* __Will the data be modified or changed before or after being moved to the Analytical Platform?__
+Personal data is information that relates to an individual who can be identified or who is identifiable:
 
-#### Personal data
+*   directly from the information in question
+*   indirectly from the information in question in combination with other information
 
-* __Does the data include personal data?__  
-  Personal data is information that can be used to identify a person directly or indirectly in combination with other information. Personal data includes names, identification numbers, addresses and online identifiers. Guidance from the Information Commissioner's Office (ICO) on identifying personal data can be found [here](https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/key-definitions/what-is-personal-data/). Further information on handling personal data in MoJ can be found [here](https://intranet.justice.gov.uk/guidance/knowledge-information/protecting-information/personal-data/).
-  
-#### Data controller
+Personal data could include information such as:
 
-* __Is MoJ the data controller responsible for the data?__  
-  A data controller is an entity registered with the Information Commissioner's Office (ICO) that exercises overall control over the purposes and means of the processing of personal data. MoJ is the controller for MoJ HQ, HMPPS, HMCTS, LAA, OPG and some other agencies and public bodies. The Analytical Platform guidance contains a list of agencies and arm's length bodies that are data controllers in their own right. The relevant information asset owner (IAO) should also be able to advise who the correct data controller is.
-* __Who is the data controller responsible for the data?__  
+*   names
+*   personal identifiers
+*   dates of birth
+*   addresses
+
+You can find detailed guidance from the ICO on what constitutes personal data [here](https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/key-definitions/what-is-personal-data/). Further information on handling personal data in MoJ can be found [here](https://intranet.justice.gov.uk/guidance/knowledge-information/protecting-information/personal-data/).
+
+#### Anonymisation and pseudonymisation
+
+Anonymisation is the process of removing personal information from data such that individuals can no longer be identified. Data that has been fully anonymised is not considered personal data and is not subject to the GDPR.
+
+> The principles of data protection should therefore not apply to anonymous information, namely information which does not relate to an identified or identifiable natural person or to personal data rendered anonymous in such a manner that the data subject is not or no longer identifiable.
+> 
+> Source: [GDPR](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32016R0679)
+
+If it is possible to identify an individual from the data by any reasonable means, the data will not have been fully anonymised but rather pseudonymised.
+
+> Pseudonymisation means the processing of personal data in such a manner that the personal data can no longer be attributed to a specific data subject without the use of additional information, provided that such additional information is kept separately and is subject to technical and organisational measures to ensure that the personal data are not attributed to an identified or identifiable natural person.
+> 
+> Source: [GDPR](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32016R0679)
+
+Pseudonymisation may involve replacing names or other personal identifiers with reference numbers or other artificial identifiers, while maintaining a lookup enabling individuals to be re-identified.
+
+Pseudonymised data is still considered personal data and is subject to the GDPR.
+
+You should try to anonymise or pseudonymise personal data where possible in accordance with the principles of [data minimisation](https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/principles/data-minimisation/) and [storage limitation](https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/principles/storage-limitation/).
+
+#### Data controllers
+
+When working with personal data, you should determine whether MoJ is the data controller.
+
+A data controller is an entity registered with the Information Commissioner's Office (ICO) that exercises overall control over the purposes and means of the processing of personal data. MoJ is the controller for MoJ HQ, HMPPS, HMCTS, LAA, OPG and some other agencies and public bodies.
+
 The data controller could be another MoJ agency or public body (for which MoJ is not the responsible controller), another government department or a third party. You can use the [ICO Data Protection Register](https://ico.org.uk/ESDWebPages/Search) to determine whether an entity is a controller. The following agencies and public bodies are data controllers:
-    + Criminal Injuries Compensation Authority (CICA)
-    + Children and Family Court Advisory and Support Service (CAFCASS)
-    + Criminal Cases Review Commission (CCRC)
-    + Legal Services Board (LSB)
-    + Parole Board for England and Wales
-    + Youth Justice Board for England and Wales (YJB)
-    + Civil Justice Council (CJC)
-    + Family Justice Council (FJC)
-    + Sentencing Council for England and Wales
-    + Office for Legal Complaints (Legal Ombudsman for England and Wales)
-    + The Official Solicitor to the Senior Courts
-    + The Public Trustee
-    + Prisons and Probation Ombudsman (PPO)
-* __Is a suitable data sharing agreement in place with the data controller?__
-* __Is the controller aware of the data movement and the intended use of the Analytical Platform as a data processor?__
 
-#### Data protection and privacy
+*   Criminal Injuries Compensation Authority (CICA)
+*   Children and Family Court Advisory and Support Service (CAFCASS)
+*   Criminal Cases Review Commission (CCRC)
+*   Legal Services Board (LSB)
+*   Parole Board for England and Wales
+*   Youth Justice Board for England and Wales (YJB)
+*   Civil Justice Council (CJC)
+*   Family Justice Council (FJC)
+*   Sentencing Council for England and Wales
+*   Office for Legal Complaints (Legal Ombudsman for England and Wales)
+*   The Official Solicitor to the Senior Courts
+*   The Public Trustee
+*   Prisons and Probation Ombudsman (PPO)
 
-* __Have the relevant Data Protection Impact Assessments (DPIAs) and Privact Impact Assessments (PIAs) been created or updated and reviewd by the data protection team?__  
-If you are unsure whether a DPIA or PIA already exists or needs to be created, you should contact the relevant Information Asset Owner (IAO). Further information on DPIAs and PIAs can be found [here](https://intranet.justice.gov.uk/guidance/knowledge-information/protecting-information/privacy-reform/data-protection-impact-assessments-dpias/). You can also contact the Data Protection Officer mailbox [here](mailto:data.compliance@justice.gov.uk).
-* __Have the relevant privacy notices been updated to reflect use of the Analytical Platform?__  
-A privacy notice is required to let customers using a product or service know:
-    + who is collecting the data;
-    + what data is being collected;
-    + if they are required to provide the data;
-    + what is the legal basis for processing the data;
-    + how the data will be used;
-    + if the data will be shared with any third parties;
-    + how long the data will be held for;
-    + if the data will be used for automated deecision-making, including profiling;
-    + what rights they have in relation to their data; and
-    + how they can raise a complaint about the handling of their data.
-  Further information on data privacy and privacy notices can be found [here](https://intranet.justice.gov.uk/guidance/knowledge-information/protecting-information/privacy-reform/). ICO guidance can also be found [here](https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/individual-rights/right-to-be-informed/).
+#### Moving personal data
 
-#### The data movement
+If you want to move personal data onto the Analytical Platform, you should check if a [Data Protection Impact Assessment (DPIA)](https://intranet.justice.gov.uk/guidance/knowledge-information/protecting-information/privacy-reform/data-protection-impact-assessments-dpias/) or Privacy Impact Assessment (PIA) already exists for the processing of the personal data. The Information Asset Owner (IAO) of the data should be able to advise you if a DPIA or PIA already exists.
 
-* __Why is the data being moved?__
-* __What is the source of the data?__
-* __Where will the data be stored on the Analytical Platform?__
-* __Which S3 bucket will the data be stored in?__
-* __How many records does the data contain?__
-* __Who will have access to the data on the Analytical Platform?__
-* __How will the data be moved?__  
-  Describe how the data will be moved from the source location. Will the data be moved electronically, by email or by physical media? Will it be uploaded manually to S3 or a home directory or will there be a direct integration with another system?
-* __Is a technical migration form required?__  
-  A technical migration form is __not required__ for one-off data movements of static files (such as .zip files and .csv files) that are carried out manually (i.e. by email or direct upload to S3 or a home directory). __A technical migration form is required for all other data movements.__ If you are unsure whether your data movement requires a technical migration form, please contact the [Analytical Platform team](mailto:analytical_platform@digital.justice.gov.uk). A template technical migration form can be found [here](https://justiceuk.sharepoint.com/:w:/s/AnalyticalPlatform/EafJPVHk2NRCjZm1WGFPOJcBpkJ-pH8L2o0hKma2bsbWow?e=0pWGjc). To access this template, you must be signed in to Office 365. If you are unable to access the template, please contact the [Analytical Platform team](mailto:analytical_platform@digital.justice.gov.uk).
-* __Technical migration form__  
-  Please send your form as an attachment to the [Analytical Platform team](mailto:analytical_platform@digital.justice.gov.uk).
-* __Is this a one-off or recurring data movement?__
-* __When is the data movement expected to occur?__
-* __What is the intended frequency of the data movement?__
-* __When is the first data movement expected to occur?__
-* __Will the data movement be in place for a fixed period of time?__
-* __When will the final data movement occur?__
-* __When will the data movement request be reviewed?__  
-  Recurring data movements that occur indefinitely should be reviewed at least every two years.
+If a DPIA or PIA already exists, you should update the document to reflect use of the Analytical Platform.
 
-#### Data retention
+If a DPIA or PIA does not already exist, you should complete a [DPIA screening document](https://intranet.justice.gov.uk/documents/2018/05/data-protection-impact-assessments-screening-template.doc) and submit this to the Data Protection Officer (DPO) at [data.compliance@justice.gov.uk](mailto:data.compliance@justice.gov.uk).
 
-* __How long will the data be retained on the Analytical Platform?__
-* __Is this in line with departmental and Analytical Platform data retention policies?__  
-  Guidance on data retention can be found in Section \@ref(data-retention).
+You should also check if a [privacy notice](https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/individual-rights/right-to-be-informed/) already exists. A privacy notice provides information to individuals about how and why their personal data is being collected and processed.
 
-#### Information Asset Owner (IAO)
+If a privacy notice already exists, you should update it to reflect use of the Analytical Platform. In particular, you should ensure the privacy notice informs individuals that their data will be:
 
-All data in MoJ is assigned an Information Asset Owner (IAO). The IAO is responsible for the registration, labelling, storage, transfer and retention of that data.
-You should seek approval from the relevant IAO for __all__ data movements.
+*   shared with Amazon Web Services, Inc. (AWS)
+*   stored outside of the UK but within the EU
 
-* __Does the data movement require approval by an Information Asset Owner (IAO)?__
-* __IAO name__
-* __IAO email address__
-* __Has the IAO approved this data movement?__
+You should then complete the following steps, as for all movements of data onto the Analytical Platform.
 
-#### Senior Information Risk Officer (SIRO)
+### IAO and SIRO approval
 
-Information on the responsibilities of SIROs can be found [here](https://intranet.justice.gov.uk/guidance/knowledge-information/protecting-information/information-assurance-roles/).
+For all data movements, you should obtain approval from the Information Asset Owner (IAO). Depending on local information governance requirements, for some complex or high-risk data movements you may also need to obtain approval from the Senior Information Risk Officer (SIRO). The IAO should be able to advise if approval from the SIRO is required.
 
-SIRO approval may be required depending on local information assurance policies. SIRO approval is usually required when a data movement involves non-routine risks. The relevant IAO should be able to advise if SIRO approval is also required.
+### Technical migration form
 
-* __Does the data movement require approval by a Senior Information Risk Officer?__
-* __SIRO name__
-* __SIRO email address__
-* __Has the SIRO approved this data movement?__
+If the data movement involves a particularly complex integration (for example, an integration with another AWS account or database system) or is recurring, you must complete a technical migration form.
 
-#### Information assurance
+You can find a template technical migration form [here](https://justiceuk.sharepoint.com/:w:/s/AnalyticalPlatform/EafJPVHk2NRCjZm1WGFPOJcBpkJ-pH8L2o0hKma2bsbWow?e=0pWGjc).
 
-* __Have you discussed the data movement with the relevant information security team(s)?__  
-  The relevant information security teams are:
-    + __MoJ HQ__ -- [cybersecurity team](mailto:cybersecurity@digital.justice.gov.uk)
-    + __HMCTS__ -- [information assurance team](https://intranet.justice.gov.uk/about-hmcts/digital-change/information-assurance-and-data-security/)
-    + __HMPPS__ -- [information management and security team](mailto:informationmgmtsecurity@noms.gsi.gov.uk)
-* __Have you considered all other information assurance requirements, including, but not limited to, those arising under the Public Records Act, the Official Secrets Act, the Data Protection Act and the Freedom of Information Act?__
+You should submit your completed technical migration form to the Analytical Platform team at [analytical_platform@digital.justice.gov.uk](mailto:analytical_platform@digital.justice.gov.uk).
 
-#### Confirmation
+### Data movement form
 
-* __Have you read and understood the Analytical Platform guidance and acceptable use policy?__
+For all data movements, you must complete a data movement form. Before completing a data movement form, you should ensure that you have already obtained all necessary approvals and completed all other information governance requirements.
 
-### Data Minimisation
-
-It is good practice to undertake data minimisation when moving data to the Analytical Platform as all software imposes [memory limits](https://moj-analytical-services.github.io/platform_user_guidance/annexes.html#data-minimisation).
-
-Data minimisation is also a princicple of GDPR. Any personal data used should be:
-
-* adequate;
-* relevant; and
-* limited to what is necessary.
-
-In practice, you may want to consider whether a subset of a larger data set (removing irrelevant fields or observations) is sufficient for your analysis.
-
-## Data Offshoring
-
-The Analytical Platform is hosted on [Amazon Web Services (AWS)](https://aws.amazon.com/) (a US company part of the Amazon group) with primary data storage and processing locations in their [European regions](https://aws.amazon.com/about-aws/global-infrastructure/).
+The data movement form can be found [here](https://forms.office.com/Pages/ResponsePage.aspx?id=KEeHxuZx_kGp4S6MNndq2I8ebMaq5PFBoMAkkhrMYHBUQVY2VUczTUNPUzlZQTJTNjFWVUowWUxUMS4u).
 
 ## Reporting security incidents
 
-As soon as you become aware of an actual or potential security incident, including a loss of data, you should follow the guidance [here](https://intranet.justice.gov.uk/guidance/security/report-a-security-incident/) and [here](https://intranet.justice.gov.uk/guidance/security/report-a-security-incident/reporting-a-data-incident/).
+As soon as you become aware of an actual or potential security incident, including a loss of data, you should follow the guidance [here](https://intranet.justice.gov.uk/guidance/security/report-a-security-incident/).

--- a/14-Annex.Rmd
+++ b/14-Annex.Rmd
@@ -102,25 +102,3 @@ Note: If you get the error 'Wrong or expired code', you need to make sure that y
 #### You're now done
 
 Once you're entered your platform 2FA code in the interface above, you should now have access to the platform.  You will need to enter your platform 2FA code around once a day as you use the platform.
-
-## Data Minimisation
-
-In order to reduce cybersecurity/information risks to data and promote/maintain a privacy-centered approach you should consider how data can be minimised or obfuscated before being imported if you can do so while maintaining analytical usefulness and data integrity.
-
-### Pseudonymisation{#pseudonymisation}
-
-Pseudonymisation is "...the processing of personal data in such a manner that the personal data can no longer be attributed to a specific data subject without the use of additional information..."
-
-An example of pseudonymisation would be replacing the name of an individual with a unique hashed value. This would preserve the concept of an individual person but would mean their name is not stored in the Analytical Platform when it is not directly needed.
-
-This is pseudonymisation as the Analytical Platform with the data that it now holds can no longer identify that person without other data that it likely does not have.
-
-### Anonymisation{#anonymisation}
-
-Anonymisation is "...information which does not relate to an identified or identifiable natural person or to personal data rendered anonymous in such a manner that the data subject is not or no longer identifiable [even when joined with other accessible data]..."
-
-Under current data protection legislation, true anonymisation is quite hard to achieve but should be considered.
-
-An example of anonymisation would be using summary values such as where there are 1000 unique 'users' in your database, the Analytical Platform held data only holds the '1000' information, not each individual user record.
-
-This is anonymisation as the Analytical Platform with the data that it now holds can no longer identify any person at all, as it will be mathematically impossible to use the number '1000' to identify any individual.


### PR DESCRIPTION
Incorporates various updates:
* reflects current DPO guidance on moving personal data to the Analytical Platform
* removes distinction between DOM1 and Quantum users
* makes language consistent
* states email addresses explicitly in accordance with the GDS style guide
* moves information on anonymisation and pseudonymisation from the annex to the information governance chapter
* removes detailed data movement form guidance – I think this is excessive and everything here is also in the form itself